### PR TITLE
Support padding engines

### DIFF
--- a/ff1/ff1.go
+++ b/ff1/ff1.go
@@ -599,7 +599,11 @@ func (c Cipher) ciph(input []byte) ([]byte, error) {
 		return nil, errors.New("length of ciph input must be multiple of 16")
 	}
 
-	c.cbcEncryptor.CryptBlocks(input, input)
+	// Some crypto engines (e.g. PKCS7) always do padding (i.e. additional block is added), we need output buffer one block bigger
+	ciphertext := make([]byte, len(input)+blockSize)
+	c.cbcEncryptor.CryptBlocks(ciphertext, input)
+	// This FF1 implementation is update buffer in-place, copy result back to input
+	copy(input, ciphertext[:len(input)])
 
 	// Reset IV to 0
 	c.cbcEncryptor.(cbcMode).SetIV(ivZero)


### PR DESCRIPTION
Some crypto engines (e.g. PKCS7) always do padding (i.e. even input is aligned with block size, additional block is added to output of encryption). Make changes to support these engines

## What's in this PR?

Please provide a description of what is contained in this Pull Request.

## TODOs

If there are some outstanding items you would like to complete before this PR is reviewed/merged, note them here. If not, feel free to remove this section.

  - [ ] TODO 1

## Housekeeping Items

  - [ ] Did you accept and sign the [Contributor License Agreement](CONTRIBUTING.md)
  - [ ] Do you agree to the [Open Source Code of Conduct](https://developer.capitalone.com/single/code-of-conduct/)?
